### PR TITLE
Add dev Docker compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ git clone https://github.com/your‑org/self-tune && cd self-tune
 $ bun install
 
 # 3. Bootstrap Temporalite & Postgres (Docker Compose)
-$ bun run dev:stack
+$ bun run dev:stack      # starts Temporalite on :7233 and Postgres on :5432
 
 # 4. Run first ingestion demo (example blog RSS)
 $ bun cli ingest rss https://yourblog.com/rss.xml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+services:
+  temporalite:
+    image: temporalio/temporalite:latest
+    ports:
+      - "7233:7233"
+    volumes:
+      - temporalite_data:/var/lib/temporalite
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: selftune
+      POSTGRES_PASSWORD: selftune
+      POSTGRES_DB: selftune
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:
+  temporalite_data:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "nx build",
     "test": "nx test",
     "lint": "nx lint",
-    "format": "nx format:write"
+    "format": "nx format:write",
+    "dev:stack": "docker compose up"
   },
   "devDependencies": {
     "nx": "19.6.0",


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` for Temporalite and Postgres
- expose a `dev:stack` script
- document stack usage in the Quick Start guide

## Testing
- `bun x tsc --noEmit`
- `bun vitest run` *(fails: No test files found)*
- `bun x eslint . --max-warnings 0` *(fails: all files matching "." are ignored)*

------
https://chatgpt.com/codex/tasks/task_b_6875179d1e9883298d8acc6baaedfe0b