### PR TITLE
Add MkDocs docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install mkdocs
+      - run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Self-Tune Documentation
+
+Welcome to the **Self-Tune** documentation site. Here you'll find tutorials, API references and design notes for building your own local fine-tuning workflows.
+
+- **Quick Start** – Get the platform running locally with Bun and Temporalite.
+- **Architecture Overview** – Learn how connectors, preprocessors and workers fit together.
+- **Development Plan** – Roadmap and open stories live in [development-plan.md](../development-plan.md).
+
+This site is generated with [MkDocs](https://www.mkdocs.org/) and deployed automatically via GitHub Pages.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,13 @@
+site_name: Self-Tune
+site_url: https://your-org.github.io/self-tune
+repo_url: https://github.com/your-org/self-tune
+nav:
+  - Home: index.md
+plugins:
+  - search
+theme:
+  name: mkdocs
+  palette:
+    - scheme: default
+      primary: indigo
+


### PR DESCRIPTION
## Summary
- add docs folder with index page
- configure MkDocs for GitHub Pages
- deploy using actions/deploy-pages

## Testing
- `bun x tsc --noEmit`
- `bun vitest run` *(fails: No test files found)*
- `bun x eslint . --max-warnings 0` *(fails: all files ignored)*

------
https://chatgpt.com/codex/tasks/task_b_687517a149788329a59445de966f6f24